### PR TITLE
Add readme contributors

### DIFF
--- a/README.Japanese.md
+++ b/README.Japanese.md
@@ -49,6 +49,11 @@ Github上のリポジトリをあなたのアカウントでフォークして�
 → [Noto Fonts リポジトリ](https://github.com/googlefonts/noto-fonts) <br>
 → [Noto CJK リポジトリ](https://github.com/googlefonts/noto-cjk)
 
+---
+
+English Readme by @riomarmccartney & @nancytru
+日本語Readme by @matarillo
+
 ## お問い合わせ
 
 → design@ookamiinc.com

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ This project is based off [Noto Sans JP](https://fonts.google.com/specimen/Noto+
 → [Noto Fonts Repository](https://github.com/googlefonts/noto-fonts) <br>
 → [Noto CJK Repository](https://github.com/googlefonts/noto-cjk)
 
+---
+
+English readme authored by @riomarmccartney & @nancytru
+Japanese readme authored by @matarillo
+
 ## Inquiries
 
 → design@ookamiinc.com


### PR DESCRIPTION
When merging #19 Github didn't add the authored person in the contributor to this project. 
This fixes that by adding readme contributors directly into the text.